### PR TITLE
Status HTTP

### DIFF
--- a/api_node.js
+++ b/api_node.js
@@ -6,7 +6,7 @@ console.log('Base Api NodeJS Criado Por CarlosDev')
 // App Get
 
 app.get('/', (req,res) => {
-    res.send('Forbidden')
+    res.status(403).send('Forbidden')
         
 })
 


### PR DESCRIPTION
Como o acesso ao / é proibido é boa prática mandar o status http que corresponde a isso assim quando tentarem acessar a api  dará erro e não vai mandar uma mensagem normal e sim uma mensagem de erro